### PR TITLE
CI: Change to have setup-py-changes only run on pushes to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
   setup-py-changes:
     name: Check setup.py changes (new version)
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     outputs:
       setup_changes: ${{ steps.filter.outputs.setup }}
     steps:
@@ -75,7 +76,6 @@ jobs:
     name: TestPyPI - Build and publish Python distributions
     runs-on: ubuntu-latest
     needs: [pytest, setup-py-changes]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
 
       - name: Checkout Code Repository


### PR DESCRIPTION
**Changes:**
* Only have setup-py-changes run on push to master